### PR TITLE
Fix issue with base path while extracting logs.

### DIFF
--- a/extract-git-logs/extract-logs.ps1
+++ b/extract-git-logs/extract-logs.ps1
@@ -87,7 +87,7 @@ try {
     $gitRepos = Get-ChildItem -recurse -Directory -Path $allProjectsFolder -Force -depth $nestedFolders -ErrorAction stop | Where-Object { $_.name -eq ".git" }
     write-host "Extracting logs.." -ForegroundColor DarkYellow -NoNewline
     foreach ($gitrepo in $gitRepos) {
-        $gitrepoFolderPath = "$($allProjectsFolder)/$($gitrepo.Parent)"
+        $gitrepoFolderPath = Join-Path -Path $allProjectsFolder -childPath $gitrepo.Parent
         $gitrepoName = $(get-item -path $gitrepoFolderPath ).name
         Set-Location -Path $gitrepoFolderPath -ErrorAction Stop > $null
         $gitlogfilename = "{0}-{1}.csv" -f $gitrepoName, $($gitAuthor -replace " ", "")

--- a/extract-git-logs/extract-logs.ps1
+++ b/extract-git-logs/extract-logs.ps1
@@ -87,7 +87,7 @@ try {
     $gitRepos = Get-ChildItem -recurse -Directory -Path $allProjectsFolder -Force -depth $nestedFolders -ErrorAction stop | Where-Object { $_.name -eq ".git" }
     write-host "Extracting logs.." -ForegroundColor DarkYellow -NoNewline
     foreach ($gitrepo in $gitRepos) {
-        $gitrepoFolderPath = $gitrepo.Parent
+        $gitrepoFolderPath = "$($allProjectsFolder)/$($gitrepo.Parent)"
         $gitrepoName = $(get-item -path $gitrepoFolderPath ).name
         Set-Location -Path $gitrepoFolderPath -ErrorAction Stop > $null
         $gitlogfilename = "{0}-{1}.csv" -f $gitrepoName, $($gitAuthor -replace " ", "")


### PR DESCRIPTION
We had to add this fix since we had a folder structure with a base folder were we store all the repositories and we were running the tool from other folder. It caused the base folder was not the correct one.